### PR TITLE
Add close button to settings menu

### DIFF
--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -548,6 +548,11 @@ export default function Settings({
               Update available! Version {latestAppVersion}
             </Alert>
           )}
+          <Stack direction="row" justifyContent="flex-end" mt={2}>
+            <Button variant="outlined" onClick={() => setOpen(false)}>
+              Close
+            </Button>
+          </Stack>
         </DialogContent>
       </Dialog>
     </>


### PR DESCRIPTION
Clicking out or pressing esc doesn't work on Windows it seems, so this close button will save someone from having to close out of the app to get out of the settings menu.