### PR TITLE
Add setting to format doubles output as team vs team

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -932,6 +932,22 @@ export default function setupIPCs(
     }
   });
 
+  ipcMain.removeHandler('getDoublesTeamFormat');
+  ipcMain.handle('getDoublesTeamFormat', () => {
+    if (store.has('doublesTeamFormat')) {
+      return store.get('doublesTeamFormat') as boolean;
+    }
+    store.set('doublesTeamFormat', false);
+    return false;
+  });
+  ipcMain.removeHandler('setDoublesTeamFormat');
+  ipcMain.handle(
+    'setDoublesTeamFormat',
+    (event, newDoublesTeamFormat: boolean) => {
+      store.set('doublesTeamFormat', newDoublesTeamFormat);
+    },
+  );
+
   ipcMain.removeHandler('getEnforcerSetting');
   ipcMain.handle('getEnforcerSetting', () => enforcerSetting);
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -188,6 +188,10 @@ const electronHandler = {
   getUseLAN: (): Promise<boolean> => ipcRenderer.invoke('getUseLAN'),
   setUseLAN: (useLAN: boolean): Promise<void> =>
     ipcRenderer.invoke('setUseLAN', useLAN),
+  getDoublesTeamFormat: (): Promise<boolean> =>
+    ipcRenderer.invoke('getDoublesTeamFormat'),
+  setDoublesTeamFormat: (doublesTeamFormat: boolean): Promise<void> =>
+    ipcRenderer.invoke('setDoublesTeamFormat', doublesTeamFormat),
   getEnforcerSetting: (): Promise<EnforcerSetting> =>
     ipcRenderer.invoke('getEnforcerSetting'),
   setEnforcerSetting: (enforcerSetting: EnforcerSetting): Promise<void> =>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -200,6 +200,7 @@ function Hello() {
 
   // settings
   const [mode, setMode] = useState<Mode>(Mode.STARTGG);
+  const [doublesTeamFormat, setDoublesTeamFormat] = useState(false);
   const [enforcerSetting, setEnforcerSetting] = useState(EnforcerSetting.NONE);
   const [vlerkMode, setVlerkMode] = useState(false);
   const [vlerkModeExternalId, setVlerkModeExternalId] = useState(-1);
@@ -266,6 +267,7 @@ function Hello() {
       const modePromise = window.electron.getMode();
       const useLANPromise = window.electron.getUseLAN();
       const enforcerSettingPromise = window.electron.getEnforcerSetting();
+      const doublesTeamFormatPromise = window.electron.getDoublesTeamFormat();
       const vlerkModePromise = window.electron.getVlerkMode();
       const guidedModePromise = window.electron.getGuidedMode();
       const fileNameFormatPromise = window.electron.getFileNameFormat();
@@ -296,6 +298,7 @@ function Hello() {
       setAppVersion(await appVersionPromise);
       setMode(await modePromise);
       setUseLAN(await useLANPromise);
+      setDoublesTeamFormat(await doublesTeamFormatPromise);
       setEnforcerSetting(await enforcerSettingPromise);
       setFileNameFormat(await fileNameFormatPromise);
       setFolderNameFormat(await folderNameFormatPromise);
@@ -1400,16 +1403,17 @@ function Hello() {
           }
         });
 
+        const playersSeparator = doublesTeamFormat ? ', ' : ' + ';
         const playersOnly = `${entrant1CombinedNameObjs
           .map(combinedNameObjToPlayerOnly)
-          .join(' + ')} vs ${entrant2CombinedNameObjs
+          .join(playersSeparator)} vs ${entrant2CombinedNameObjs
           .map(combinedNameObjToPlayerOnly)
-          .join(' + ')}`;
+          .join(playersSeparator)}`;
         const playersChars = `${entrant1CombinedNameObjs
           .map(combinedNameObjToPlayerChar)
-          .join(' + ')} vs ${entrant2CombinedNameObjs
+          .join(playersSeparator)} vs ${entrant2CombinedNameObjs
           .map(combinedNameObjToPlayerChar)
-          .join(' + ')}`;
+          .join(playersSeparator)}`;
         const singlesChars =
           combinedNameObjs.length === 4 ? playersOnly : playersChars;
         subdir = String(folderNameFormat);
@@ -1456,10 +1460,43 @@ function Hello() {
             : startAt;
           const time = format(writeStartDate, 'HHmmss');
           const names = game.filter((nameObj) => nameObj.characterName);
-          const playersOnly = names.map(nameObjToPlayerOnly).join(', ');
-          const playersChars = names.map(nameObjToPlayerChar).join(', ');
-          const singlesChars =
-            nameObjs.length === 4 ? playersOnly : playersChars;
+          let playersOnly: string;
+          let playersChars: string;
+
+          // For doubles, use team vs team format matching the folder name
+          if (names.length === 4 && selectedReplays[i].isTeams) {
+            // Group players by entrant for team vs team format
+            const entrant1Names: NameObj[] = [];
+            const entrant2Names: NameObj[] = [];
+
+            names.forEach((nameObj) => {
+              const isEntrant1 = entrant1CombinedNameObjs.some(
+                (cbn) => cbn.participantId === nameObj.participantId,
+              );
+              if (isEntrant1) {
+                entrant1Names.push(nameObj);
+              } else {
+                entrant2Names.push(nameObj);
+              }
+            });
+
+            playersOnly = `${entrant1Names
+              .map(nameObjToPlayerOnly)
+              .join(', ')} vs ${entrant2Names
+              .map(nameObjToPlayerOnly)
+              .join(', ')}`;
+            playersChars = `${entrant1Names
+              .map(nameObjToPlayerChar)
+              .join(', ')} vs ${entrant2Names
+              .map(nameObjToPlayerChar)
+              .join(', ')}`;
+          } else {
+            // For singles, use the original format
+            playersOnly = names.map(nameObjToPlayerOnly).join(', ');
+            playersChars = names.map(nameObjToPlayerChar).join(', ');
+          }
+
+          const singlesChars = names.length === 4 ? playersOnly : playersChars;
 
           let fileName = `{ordinal}${fileNameFormat}`;
           fileName = fileName.replace(
@@ -2643,6 +2680,8 @@ function Hello() {
                   guideBackdropOpen &&
                   guideState === GuideState.PLAYERS
                 }
+                doublesTeamFormat={doublesTeamFormat}
+                setDoublesTeamFormat={setDoublesTeamFormat}
                 enforcerVersion={ENFORCER_VERSION}
                 enforcerSetting={enforcerSetting}
                 smuggleCostumeIndex={smuggleCostumeIndex}

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -63,6 +63,8 @@ export default function Settings({
   setSmuggleCostumeIndex,
   useLAN,
   setUseLAN,
+  doublesTeamFormat,
+  setDoublesTeamFormat,
   fileNameFormat,
   setFileNameFormat,
   folderNameFormat,
@@ -86,6 +88,8 @@ export default function Settings({
   setSmuggleCostumeIndex: (smuggleCostumeIndex: boolean) => void;
   useLAN: boolean;
   setUseLAN: (useLAN: boolean) => void;
+  doublesTeamFormat: boolean;
+  setDoublesTeamFormat: (doublesTeamFormat: boolean) => void;
   fileNameFormat: string;
   setFileNameFormat: (fileNameFormat: string) => void;
   folderNameFormat: string;
@@ -425,6 +429,15 @@ export default function Settings({
               set={async (checked) => {
                 await window.electron.setUseLAN(checked);
                 setUseLAN(checked);
+              }}
+            />
+            <LabeledCheckbox
+              checked={doublesTeamFormat}
+              label="Format doubles names as team vs team"
+              labelPlacement="end"
+              set={async (checked) => {
+                await window.electron.setDoublesTeamFormat(checked);
+                setDoublesTeamFormat(checked);
               }}
             />
             {mode === Mode.STARTGG && (


### PR DESCRIPTION
Currently, doubles output will be formatted as each player in port order. This commit adds a setting which will format doubles output as "team1player1, team1player2 vs team2player1, team2player2".